### PR TITLE
Still show merge details even when button is hidden

### DIFF
--- a/autosquash_please.js
+++ b/autosquash_please.js
@@ -80,7 +80,8 @@ loadOptions().then((options) => {
             if (commitMessages.find(isFixupCommits)) {
                 console.log('[autosquash-please] A fixup! commit is found.');
                 let mergeDetails = document.getElementById('partial-pull-merging');
-                mergeDetails.innerHTML = '<p class="merge-pr-more-commits" style="font-weight: bold; font-size: 150%; color: red;">The autosquash-please addon prevents to push merge button.</p>';
+                let mergeButton = mergeDetails.getElementsByClassName('merge-message')[0]
+                mergeButton.innerHTML = '<p class="merge-pr-more-commits" style="font-weight: bold; font-size: 150%; color: red;">The autosquash-please addon prevents to push merge button.</p>';
 
             } else {
                 console.log('[autosquash-please] No fixup! commits.');

--- a/autosquash_please.js
+++ b/autosquash_please.js
@@ -81,7 +81,7 @@ loadOptions().then((options) => {
                 console.log('[autosquash-please] A fixup! commit is found.');
                 let mergeDetails = document.getElementById('partial-pull-merging');
                 let mergeButton = mergeDetails.getElementsByClassName('merge-message')[0]
-                mergeButton.innerHTML = '<p class="merge-pr-more-commits" style="font-weight: bold; font-size: 150%; color: red;">The autosquash-please addon prevents to push merge button.</p>';
+                mergeButton.innerHTML = '<p class="merge-pr-more-commits" style="font-weight: bold; font-size: 150%; color: red;">The autosquash-please addon prevents pressing merge button.</p>';
 
             } else {
                 console.log('[autosquash-please] No fixup! commits.');


### PR DESCRIPTION
## What
Still show merge details (status checks, etc.) even when button is hidden.

## Why
The `partial-pull-merging` div is also used to show status checks which we still want to see even if we cannot actually perform the merge.
This change could also be made as a selectable option in the options view, but I couldn't think of a reason not to show the status checks...

## How
Specify a different target for replacing the HTML.